### PR TITLE
Added connection.release() to free the individual connections handed …

### DIFF
--- a/backend/src/utils/database.utils.ts
+++ b/backend/src/utils/database.utils.ts
@@ -1,7 +1,7 @@
 import { Pool, createPool, PoolConnection } from 'mysql2/promise'
 let globalPool: Pool | undefined
 export async function connect (): Promise<PoolConnection> {
-  if (globalPool) {
+  if (globalPool != null) {
     return await globalPool.getConnection()
   }
   globalPool = await createPool({

--- a/backend/src/utils/like/deleteLike.ts
+++ b/backend/src/utils/like/deleteLike.ts
@@ -5,5 +5,6 @@ export async function deleteLike (like: Like): Promise<string> {
   const mySqlConnection = await connect()
   const mySqlDelete = 'DELETE FROM `like` WHERE likeProfileId = UUID_TO_BIN(:likeProfileId) AND likeTweetId = UUID_TO_BIN(:likeTweetId)'
   await mySqlConnection.execute(mySqlDelete, like)
+  await mySqlConnection.release()
   return 'Like successfully deleted'
 }

--- a/backend/src/utils/like/insertLike.ts
+++ b/backend/src/utils/like/insertLike.ts
@@ -5,5 +5,6 @@ export async function insertLike (like: Like): Promise<string> {
   const mySqlConnection = await connect()
   const mySqlQuery = 'INSERT INTO `like`(likeProfileId, likeTweetId, likeDate) VALUES(UUID_TO_BIN(:likeProfileId), UUID_TO_BIN(:likeTweetId), NOW())'
   await mySqlConnection.execute(mySqlQuery, like)
+  await mySqlConnection.release()
   return 'Like successfully inserted'
 }

--- a/backend/src/utils/like/selectLikeByLikeId.ts
+++ b/backend/src/utils/like/selectLikeByLikeId.ts
@@ -7,6 +7,7 @@ export async function selectLikeByLikeId (like: Like): Promise<Like|null> {
   const mysqlConnection = await connect()
   const mySqlSelectQuery = 'SELECT BIN_TO_UUID(likeProfileId) as likeProfileId, BIN_TO_UUID(likeTweetId) as likeTweetId, likeDate FROM `like` WHERE likeProfileId = UUID_TO_BIN(:likeProfileId) AND likeTweetId = UUID_TO_BIN(:likeTweetId)'
   const result: RowDataPacket[] = await mysqlConnection.execute(mySqlSelectQuery, like) as RowDataPacket[]
+  await mysqlConnection.release()
   const rows: Like[] = result[0] as Like[]
   return rows.length !== 0 ? { ...rows[0] } : null
 }

--- a/backend/src/utils/profile/insertProfile.ts
+++ b/backend/src/utils/profile/insertProfile.ts
@@ -5,6 +5,6 @@ export async function insertProfile (profile: Profile): Promise<string> {
   const mysqlConnection = await connect()
   const query: string = 'INSERT INTO profile(profileId, profileActivationToken, profileAtHandle, profileAvatarUrl,  profileEmail, profileHash, profilePhone ) VALUES (UUID_TO_BIN(UUID()) , :profileActivationToken, :profileAtHandle, :profileAvatarUrl, :profileEmail, :profileHash, :profilePhone)'
   await mysqlConnection.execute(query, profile)
-  await mysqlConnection.end()
+  await mysqlConnection.release()
   return 'Profile Successfully Created'
 }

--- a/backend/src/utils/profile/selectPartialProfileByProfileId.ts
+++ b/backend/src/utils/profile/selectPartialProfileByProfileId.ts
@@ -7,5 +7,6 @@ export async function selectPartialProfileByProfileId (profileId: string): Promi
   const mysqlQuery: string = 'SELECT BIN_TO_UUID(profileId) as profileId,  profileAtHandle, profileAvatarUrl, profileEmail, profilePhone FROM profile WHERE profileId = UUID_TO_BIN(:profileId)'
   const result: RowDataPacket[] = await mysqlConnection.execute(mysqlQuery, { profileId }) as RowDataPacket[]
   const rows: PartialProfile[] = result[0] as PartialProfile[]
+  await mysqlConnection.release()
   return rows.length !== 0 ? { ...rows[0] } : null
 }

--- a/backend/src/utils/profile/selectProfileByProfileActivationToken.ts
+++ b/backend/src/utils/profile/selectProfileByProfileActivationToken.ts
@@ -7,5 +7,6 @@ export async function selectProfileByProfileActivationToken (profileActivationTo
   const mysqlQuery: string = 'SELECT BIN_TO_UUID(profileId) as profileId,  profileAtHandle, profileAvatarUrl, profileEmail, profilePhone FROM profile WHERE profileActivationToken = :profileActivationToken'
   const result = await mysqlConnection.execute(mysqlQuery, { profileActivationToken }) as RowDataPacket[]
   const rows: Profile[] = result[0] as Profile[]
+  await mysqlConnection.release()
   return rows.length === 1 ? { ...rows[0] } : null
 }

--- a/backend/src/utils/profile/selectProfileByProfileEmail.ts
+++ b/backend/src/utils/profile/selectProfileByProfileEmail.ts
@@ -7,5 +7,6 @@ export async function selectProfileByProfileEmail (profileEmail: string): Promis
   const sqlQuery: string = 'SELECT BIN_TO_UUID(profileId) as profileId, profileActivationToken, profileAtHandle, profileAvatarUrl, profileEmail, profileHash, profilePhone FROM profile WHERE profileEmail = :profileEmail'
   const result = await mysqlConnection.execute(sqlQuery, { profileEmail }) as RowDataPacket[]
   const rows: Profile[] = result[0] as Profile[]
+  await mysqlConnection.release()
   return rows.length === 1 ? { ...rows[0] } : null
 }

--- a/backend/src/utils/profile/selectWholeProfileByProfileId.ts
+++ b/backend/src/utils/profile/selectWholeProfileByProfileId.ts
@@ -7,5 +7,6 @@ export async function selectWholeProfileByProfileId (profileId: string): Promise
   const sqlQuery: string = 'SELECT BIN_TO_UUID(profileId) as profileId, profileActivationToken,  profileAtHandle, profileAvatarUrl, profileEmail, profileHash,profilePhone FROM profile WHERE profileId = UUID_TO_BIN(:profileId)'
   const result = await mysqlConnection.execute(sqlQuery, { profileId }) as RowDataPacket[]
   const rows: Profile[] = result[0] as Profile[]
+  await mysqlConnection.release()
   return rows.length === 1 ? { ...rows[0] } : null
 }

--- a/backend/src/utils/profile/updateProfile.ts
+++ b/backend/src/utils/profile/updateProfile.ts
@@ -6,5 +6,6 @@ export async function updateProfile (profile: Profile): Promise<string> {
   const mysqlConnection = await connect()
   const query: string = 'UPDATE profile SET profileActivationToken = :profileActivationToken, profileAtHandle = :profileAtHandle, profileAvatarUrl = :profileAvatarUrl, profileEmail = :profileEmail,  profilePhone = :profilePhone WHERE profileId = UUID_TO_BIN(:profileId)'
   await mysqlConnection.execute(query, profile)
+  await mysqlConnection.release()
   return 'Profile successfully updated'
 }

--- a/backend/src/utils/tweet/insertTweet.ts
+++ b/backend/src/utils/tweet/insertTweet.ts
@@ -5,5 +5,6 @@ export async function insertTweet (tweet: Tweet): Promise<string> {
   const mySqlConnection = await connect()
   const mySqlQuery = 'INSERT INTO tweet(tweetId, tweetProfileId, tweetContent, tweetDate ) VALUES(UUID_TO_BIN(UUID()), UUID_TO_BIN(:tweetProfileId), :tweetContent, NOW())'
   await mySqlConnection.execute(mySqlQuery, tweet)
+  await mySqlConnection.release()
   return 'Tweet created successfully'
 }

--- a/backend/src/utils/tweet/selectAllTweets.ts
+++ b/backend/src/utils/tweet/selectAllTweets.ts
@@ -6,5 +6,6 @@ export async function selectAllTweets (): Promise<Tweet[]> {
   const mySqlConnection = await connect()
   const mySqlQuery = 'SELECT BIN_TO_UUID(tweetId) AS tweetId, BIN_TO_UUID (tweetProfileId) AS tweetProfileId, tweetContent, tweetDate, profile.profileAtHandle, profile.profileAvatarUrl, (SELECT COUNT(*) FROM `like` WHERE tweet.tweetId = like.likeTweetId) AS likeCount FROM tweet INNER JOIN profile ON profile.profileId = tweet.tweetProfileId ORDER BY tweetDate DESC'
   const result = await mySqlConnection.execute(mySqlQuery) as RowDataPacket[]
+  await mySqlConnection.release()
   return result[0] as Tweet[]
 }

--- a/backend/src/utils/tweet/selectTweetByTweetId.ts
+++ b/backend/src/utils/tweet/selectTweetByTweetId.ts
@@ -7,5 +7,6 @@ export async function selectTweetByTweetId (tweetId: string): Promise<Tweet|null
   const mySqlQuery = 'SELECT BIN_TO_UUID(tweetId) AS tweetId, BIN_TO_UUID (tweetProfileId) AS tweetProfileId, tweetContent, tweetDate from tweet WHERE tweetId = UUID_TO_BIN(:tweetId)'
   const result = await mySqlConnection.execute(mySqlQuery, { tweetId }) as RowDataPacket[]
   const tweets: Tweet[] = result[0] as Tweet[]
+  await mySqlConnection.release()
   return tweets.length === 1 ? { ...tweets[0] } : null
 }

--- a/backend/src/utils/tweet/selectTweetsByTweetProfileId.ts
+++ b/backend/src/utils/tweet/selectTweetsByTweetProfileId.ts
@@ -6,5 +6,6 @@ export async function selectTweetsByTweetProfileId (tweetProfileId: string): Pro
   const mySqlConnection = await connect()
   const mySqlQuery = 'SELECT BIN_TO_UUID(tweetId) AS tweetId, BIN_TO_UUID (tweetProfileId) AS tweetProfileId, tweetContent, tweetDate, profile.profileAtHandle, profile.profileAvatarUrl, (SELECT COUNT(*) FROM `like` WHERE tweet.tweetId = like.likeTweetId) AS likeCount FROM tweet INNER JOIN profile ON profile.profileId = tweet.tweetProfileId WHERE tweetProfileId = UUID_TO_BIN(:tweetProfileId) ORDER BY tweetDate DESC'
   const result = await mySqlConnection.execute(mySqlQuery, { tweetProfileId }) as RowDataPacket
+  await mySqlConnection.release()
   return result[0] as Tweet[]
 }


### PR DESCRIPTION
With refactoring database.utils.ts  in pull request [36](https://github.com/Deep-Dive-Coding-Fullstack-Licensing/example-capstone/pull/36), all MySQL enabled functions in example capstone were refactored with how the connections to the database are released. If the connection is not released in the MySQL enabled function, the connection lingers, and eventually, the connection limit is reached, causing the database and Express to become unresponsive. Previously the connection was terminated without any explicit action; this was due to creating a pool of connections per function call instead of maintaining a single pool of connections that hands out a single connection per function call. 
